### PR TITLE
Check MessageVersion attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ We've done the following changes to the XML schemas to make them work for our us
 
 - Commit 7bdb761d378a4ec2922a1ea14048b614e4cd08e1: Fix references to the
   `STAND013-Components_v1p1.xsd` file. This file is in the same directory as the
-  other schemas, not in `../Components/`. This is true both for the Zip file at stand.no and in python-stand013.
+  other schemas, not in `../Components/`. This is true both for the Zip file at
+  stand.no and in python-stand013.
 
 - Commit bd9e138ac6275ccabe7ce0907157a3a83d0b5ea1: Renamed
   `STAND013 DeliveryNote_v1p1.xsd` to `STAND013-DeliveryNote_v1p1.xsd` so that
@@ -132,3 +133,8 @@ We've done the following changes to the XML schemas to make them work for our us
   enum with the values `AC`, `AE`, or `NE`) to a new `OrderResponseType` enum
   with `Z1` as the only possible value. This matches the format documentation,
   and is necessary to be able to validate any `ORDERS` using the XML schemas.
+
+- Commit d6f6995642f9c60fcf039828a888df16f230f86c: Change required content for
+  the `MessageVersion` element to be exactly `STAND013 v1.0` for `ORDERS`,
+  `ORDRSP`, and `DESADV`. This matches the requirement in the field listings in
+  the STAND013 documentation.

--- a/src/stand013/schemas/STAND013-DeliveryNote_v1p1.xsd
+++ b/src/stand013/schemas/STAND013-DeliveryNote_v1p1.xsd
@@ -8,9 +8,7 @@
 <!--STAND013 Delivery Note-->
 <!--=========================================================================-->
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-    xmlns="http://www.ean-nor.no/schemas/eannor"
-    targetNamespace="http://www.ean-nor.no/schemas/eannor"
-    elementFormDefault="qualified">
+  xmlns="http://www.ean-nor.no/schemas/eannor" targetNamespace="http://www.ean-nor.no/schemas/eannor" elementFormDefault="qualified">
   <xsd:include schemaLocation="STAND013-Components_v1p1.xsd"/>
   <xsd:element name="DeliveryNote" type="DeliveryNoteType"/>
   <xsd:complexType name="DeliveryNoteDetailsType">
@@ -353,7 +351,16 @@ Hierarkisk struktur med Pakker og tilhørende Linjer
         <xsd:documentation>= DELIVERYNOTE      (DESADV i EDIFACT)</xsd:documentation>
       </xsd:annotation>
     </xsd:attribute>
-    <xsd:attribute name="MessageVersion" type="xsd:string" use="required"/>
+    <xsd:attribute name="MessageVersion" use="required">
+      <xsd:annotation>
+        <xsd:documentation>1.0</xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:string">
+          <xsd:enumeration value="STAND013 v1.0"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:attribute>
   </xsd:complexType>
   <xsd:complexType name="RefDesadvDetailsType">
     <xsd:sequence>

--- a/src/stand013/schemas/STAND013-OrderResponse_v1p1.xsd
+++ b/src/stand013/schemas/STAND013-OrderResponse_v1p1.xsd
@@ -8,9 +8,7 @@
 <!--Order Response Message-->
 <!--===========================================================-->
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-    xmlns="http://www.ean-nor.no/schemas/eannor"
-    targetNamespace="http://www.ean-nor.no/schemas/eannor"
-    elementFormDefault="qualified">
+  xmlns="http://www.ean-nor.no/schemas/eannor" targetNamespace="http://www.ean-nor.no/schemas/eannor" elementFormDefault="qualified">
   <xsd:include schemaLocation="STAND013-Components_v1p1.xsd"/>
   <xsd:element name="OrderResponse" type="OrderResponseType">
     <xsd:annotation>
@@ -184,7 +182,7 @@
       </xsd:annotation>
       <xsd:simpleType>
         <xsd:restriction base="xsd:string">
-          <xsd:enumeration value="STAND013v1.0"/>
+          <xsd:enumeration value="STAND013 v1.0"/>
         </xsd:restriction>
       </xsd:simpleType>
     </xsd:attribute>

--- a/src/stand013/schemas/STAND013-Order_v1p1.xsd
+++ b/src/stand013/schemas/STAND013-Order_v1p1.xsd
@@ -151,10 +151,15 @@
         <xsd:documentation>Meldingstype = ORDERS</xsd:documentation>
       </xsd:annotation>
     </xsd:attribute>
-    <xsd:attribute name="MessageVersion" type="xsd:string" use="required">
+    <xsd:attribute name="MessageVersion" use="required">
       <xsd:annotation>
         <xsd:documentation>1.0</xsd:documentation>
       </xsd:annotation>
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:string">
+          <xsd:enumeration value="STAND013 v1.0"/>
+        </xsd:restriction>
+      </xsd:simpleType>
     </xsd:attribute>
   </xsd:complexType>
   <xsd:simpleType name="OrderResponseType">

--- a/tests/examples/ordrsp.xml
+++ b/tests/examples/ordrsp.xml
@@ -8,7 +8,7 @@
         <Date>2013-10-15</Date>
         <NumberOfMessages>1</NumberOfMessages>
     </Envelope>
-    <OrderResponse MessageOwner="GS1NOR" MessageType="ORDREKVITTERING" MessageVersion="STAND013v1.0">
+    <OrderResponse MessageOwner="GS1NOR" MessageType="ORDREKVITTERING" MessageVersion="STAND013 v1.0">
         <MessageNumber>1</MessageNumber>
         <MessageTimestamp>2013-10-15T15:20:00-05:00</MessageTimestamp>
         <OrderResponseHeader>


### PR DESCRIPTION
This extends the XML schemas for `OrderResponse` and `DeliveryNote` to check
the contents of the `MessageVersion` attribute, like was already done for
`Order`.
